### PR TITLE
Remove unused gems from the bundle before caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3
+            bundle clean --force
             yarn install
 
       - save_cache:


### PR DESCRIPTION
Our caches tend to grow ever larger, taking ever more time to create and
restore, because we keep installing gems and never remove the unused
ones.