### PR TITLE
Bring back the Google authentication URL

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,3 +8,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     :scope => "userinfo.email, userinfo.profile",
     :prompt => "select_account"
 end
+
+OmniAuth.config.allowed_request_methods = [:get]


### PR DESCRIPTION
Before this change /auth/google_oauth2 was returning a 404