### PR TITLE
Don't compress Javascript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,9 +38,6 @@ gem "stimulus-rails"
 gem "tailwindcss-rails"
 gem "view_component"
 
-# Assets management
-gem "uglifier"
-
 # Third-party services
 gem "httparty"
 gem "mite-rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,6 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubi (1.12.0)
     eventmachine (1.2.3)
-    execjs (2.7.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -425,8 +424,6 @@ GEM
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -488,7 +485,6 @@ DEPENDENCIES
   stimulus-rails
   tailwindcss-rails
   tzinfo-data
-  uglifier
   view_component
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts.
-  config.assets.js_compressor = Uglifier.new(:harmony => true)
+  # config.assets.js_compressor = Uglifier.new(:harmony => true)
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
Uglifier doesn't seem to like our new scripts, but I am sure we can live with them not being compressed.